### PR TITLE
Fix dependency cycle with systemd_limits and allow absent

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class qpid::params {
   $interface = undef
 
   $max_connections = undef
-  $open_file_limit = undef
+  $open_file_limit = 1 # 1 is used to denote absent condition due to how systemd::service_limits works
 
   $ssl                     = false
   $ssl_port                = 5671

--- a/manifests/router/params.pp
+++ b/manifests/router/params.pp
@@ -8,5 +8,5 @@ class qpid::router::params {
   $router_mode         = 'interior'
   $worker_threads      = $::processorcount
   $router_packages     = ['qpid-dispatch-router']
-  $open_file_limit     = undef
+  $open_file_limit     = 1 # 1 is used to denote absent condition due to how systemd::service_limits works
 }

--- a/manifests/router/service.pp
+++ b/manifests/router/service.pp
@@ -11,12 +11,20 @@ class qpid::router::service {
     hasrestart => true,
   }
 
-  if $::qpid::router::open_file_limit and $::systemd {
+  if $::qpid::router::open_file_limit != 1 {
+    $ensure_limit = 'present'
+  } else {
+    $ensure_limit = 'absent'
+  }
+
+  if $::systemd {
     systemd::service_limits { 'qdrouterd.service':
-      limits => {
+      ensure          => $ensure_limit,
+      restart_service => false,
+      notify          => Service['qdrouterd'],
+      limits          => {
         'LimitNOFILE' => $::qpid::router::open_file_limit,
       },
-      notify => Service['qdrouterd'],
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,12 +11,20 @@ class qpid::service {
     hasrestart => true,
   }
 
-  if $::qpid::open_file_limit and $::systemd {
+  if $::qpid::open_file_limit != 1 {
+    $ensure_limit = 'present'
+  } else {
+    $ensure_limit = 'absent'
+  }
+
+  if $::systemd {
     systemd::service_limits { 'qpidd.service':
-      limits => {
+      ensure          => $ensure_limit,
+      restart_service => false,
+      notify          => Service['qpidd'],
+      limits          => {
         'LimitNOFILE' => $::qpid::open_file_limit,
       },
-      notify => Service['qpidd'],
     }
   }
 }

--- a/spec/classes/qpid_client_spec.rb
+++ b/spec/classes/qpid_client_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid::client' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts
+        facts.merge!(:systemd => true)
       end
 
       context 'without parameters' do

--- a/spec/classes/qpid_config_spec.rb
+++ b/spec/classes/qpid_config_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid::config' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts
+        facts.merge!(:systemd => true)
       end
 
       context 'without parameters' do

--- a/spec/classes/qpid_router_config_spec.rb
+++ b/spec/classes/qpid_router_config_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid::router::config' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts.merge(:processorcount => 2, :systemd => true)
+        facts.merge!(:processorcount => 2, :systemd => true)
       end
 
       context 'without parameters' do

--- a/spec/classes/qpid_router_spec.rb
+++ b/spec/classes/qpid_router_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid::router' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts
+        facts.merge!(:systemd => true)
       end
 
       it { is_expected.to compile.with_all_deps }

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts
+        facts.merge!(:systemd => true)
       end
 
       context 'without parameters' do

--- a/spec/classes/qpid_tools_spec.rb
+++ b/spec/classes/qpid_tools_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid::tools' do
   on_supported_os.each do |os, facts|
     context 'on redhat' do
       let :facts do
-        facts
+        facts.merge!(:systemd => true)
       end
 
       it { is_expected.to contain_package('qpid-tools').with_ensure('installed') }

--- a/spec/defines/config_cmd_spec.rb
+++ b/spec/defines/config_cmd_spec.rb
@@ -4,7 +4,9 @@ describe 'qpid::config_cmd' do
   let (:title) { 'test' }
 
   on_os_under_test.each do |os, facts|
-    let (:facts) { facts }
+    let :facts do
+      facts.merge!(:systemd => true)
+    end
 
     [true, false].each do |qpid|
       context "qpid => #{qpid}" do

--- a/spec/defines/router_log_spec.rb
+++ b/spec/defines/router_log_spec.rb
@@ -27,7 +27,7 @@ describe 'qpid::router::log' do
 
   context 'with dependencies' do
     let :facts do
-      on_supported_os['redhat-7-x86_64']
+      on_supported_os['redhat-7-x86_64'].merge!(:systemd => true)
     end
 
     let :pre_condition do


### PR DESCRIPTION
This fixes two things:

 1) A dependency cycle that exists if both qpid and the router systemd limits are set at the same time
 2) Ensuring that if no limits are set or they are removed from something like a hiera config, that they are removed


```
[ERROR 2018-07-17T15:03:32 main]  Found 1 dependency cycle:
[ERROR 2018-07-17T15:03:32 main] (Concat_file[/etc/qpid-dispatch/qdrouterd.conf] => Concat[/etc/qpid-dispatch/qdrouterd.conf] => Class[Qpid::Router::Config] => Class[Qpid::Router::Service] => Systemd::Service_limits[qdrouterd.service] => File[/etc/systemd/system/qdrouterd.service.d/90-limits.conf] => Class[Systemd::Systemctl::Daemon_reload] => Exec[systemctl-daemon-reload] => Class[Systemd::Systemctl::Daemon_reload] => Exec[restart qpidd.service because limits] => Systemd::Service_limits[qpidd.service] => Service[qpidd] => Exec[migrate_pulp_db] => Class[Pulp::Database] => Class[Pulp] => Class[Foreman_proxy_content::Dispatch_router] => Qpid::Router::Ssl_profile[client] => Concat::Fragment[qdrouter+ssl_client.conf] => Concat_fragment[qdrouter+ssl_client.conf] => Concat::Fragment[qdrouter+ssl_client.conf] => Concat[/etc/qpid-dispatch/qdrouterd.conf] => Concat_file[/etc/qpid-dispatch/qdrouterd.conf])\nTry the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
```