### PR TITLE
Properly handle systemd_limits

### DIFF
--- a/spec/classes/qpid_router_config_spec.rb
+++ b/spec/classes/qpid_router_config_spec.rb
@@ -4,13 +4,15 @@ describe 'qpid::router::config' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts.merge(:processorcount => 2, :systemd => true)
+        facts.merge(:processorcount => 2)
       end
 
       context 'without parameters' do
         let :pre_condition do
           'include qpid::router'
         end
+
+        it { is_expected.to compile.with_all_deps }
 
         it 'should have header fragment' do
           verify_concat_fragment_exact_contents(catalogue, 'qdrouter+header.conf', [
@@ -52,6 +54,12 @@ describe 'qpid::router::config' do
             .with_owner('root')
             .with_group('root')
             .with_mode('0644')
+        end
+
+        it 'should configure systemd' do
+          is_expected.to contain_systemd__service_limits('qdrouterd.service')
+            .with_ensure('absent')
+            .that_notifies('Service[qdrouterd]')
         end
       end
 
@@ -226,6 +234,7 @@ describe 'qpid::router::config' do
 
         it 'should configure systemd' do
           is_expected.to contain_systemd__service_limits('qdrouterd.service')
+            .with_ensure('present')
             .with_limits({'LimitNOFILE' => 10000})
         end
       end

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -8,12 +8,36 @@ describe 'qpid' do
       end
 
       context 'without parameters' do
+        it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('qpid::install') }
         it { is_expected.to contain_class('qpid::config') }
         it { is_expected.to contain_class('qpid::service') }
 
         it 'should install message store by default' do
           is_expected.to contain_package('qpid-cpp-server-linearstore')
+        end
+
+        it 'should configure systemd' do
+          is_expected.to contain_systemd__service_limits('qpidd.service')
+            .with_ensure('absent')
+            .that_notifies('Service[qpidd]')
+        end
+      end
+
+      context 'with service limits' do
+        let :params do
+          {
+            :open_file_limit => 100,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'should configure systemd' do
+          is_expected.to contain_systemd__service_limits('qpidd.service')
+            .with_ensure('present')
+            .with_limits('LimitNOFILE' => 100)
+            .that_notifies('Service[qpidd]')
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ include RspecPuppetFacts
 add_custom_fact :concat_basedir, '/tmp'                                      # puppetlabs-concat
 add_custom_fact :puppet_environmentpath, '/etc/puppetlabs/code/environments' # puppetlabs-stdlib
 add_custom_fact :root_home, '/root'                                          # puppetlabs-stdlib
+add_custom_fact :systemd, true                                               # puppet-systemd
 
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef


### PR DESCRIPTION
This now allows the purging of systemd limits. It also removes a duplicate restart.

Should replace https://github.com/theforeman/puppet-qpid/pull/95