### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,3 @@ fixtures:
     stdlib:  'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     concat:  'https://github.com/puppetlabs/puppetlabs-concat.git'
     systemd: 'https://github.com/camptocamp/puppet-systemd.git'
-  symlinks:
-    qpid: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically