### PR TITLE
Refactor docs from yardoc to rdoc

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,7 +1,22 @@
-# == Class: qpid::client
-#
 # Handles Qpid client package installations and configuration
 #
+# @param version
+#   The version to ensure. Can also be installed, latest or absent.
+# @param config_file
+#   Path to the configuration file
+# @param log_level
+# @param ssl
+#   Whether to enable SSL.
+# @param ssl_port
+#   SSL port to connect to
+# @param ssl_cert_db
+#   Path to the SSL certificate database
+# @param ssl_cert_password_file
+#   Optional password for the file with the certificate database password
+# @param ssl_cert_name
+#   The name to use inside the certificate database
+# @param client_packages
+#   Packages to install
 class qpid::client(
   String $version = $qpid::client::params::version,
   Stdlib::Absolutepath $config_file = $qpid::client::params::config_file,

--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::client::params
-#
 # Default parameter values
 #
+# @api private
 class qpid::client::params {
   $version = 'installed'
   $config_file = '/etc/qpid/qpidc.conf'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::config
-#
 # Handles Qpid configuration
 #
+# @api private
 class qpid::config
 {
 

--- a/manifests/config/bind.pp
+++ b/manifests/config/bind.pp
@@ -1,21 +1,17 @@
-# Define: qpid::config::bind
-#
 # This define binds the queue with the correct messages
 #
-# === Parameters
-#
-# $queue::                      Name of the queue
-#
-# $exchange::                   Name of the exchange the queue is on
-#
-# $hostname::                   Hostname of the qpid broker
-#
-# $port::                       Port that qpid is listening on
-#
-# $ssl_cert::                   SSL cert to use for qpid-config commands
-#
-# $ssl_key::                    SSL key to use for qpid-config commands
-#
+# @param queue
+#   Name of the queue
+# @param exchange
+#   Name of the exchange the queue is on
+# @param hostname
+#   Hostname of the qpid broker
+# @param port
+#   Port that qpid is listening on
+# @param ssl_cert
+#   SSL cert to use for qpid-config commands
+# @param ssl_key
+#   SSL key to use for qpid-config commands
 define qpid::config::bind(
   $queue,
   $exchange,

--- a/manifests/config/exchange.pp
+++ b/manifests/config/exchange.pp
@@ -1,19 +1,15 @@
-# Define: qpid::config::exchange
-#
 # This define ensures an exchange exists
 #
-# === Parameters
-#
-# $exchange::                   Name of the exchange
-#
-# $hostname::                   Hostname of the qpid broker
-#
-# $port::                       Port that qpid is listening on
-#
-# $ssl_cert::                   SSL cert to use for qpid-config commands
-#
-# $ssl_key::                    SSL key to use for qpid-config commands
-#
+# @param exchange
+#   Name of the exchange
+# @param hostname
+#   Hostname of the qpid broker
+# @param port
+#   Port that qpid is listening on
+# @param ssl_cert
+#   SSL cert to use for qpid-config commands
+# @param ssl_key
+#   SSL key to use for qpid-config commands
 define qpid::config::exchange(
   $exchange = $title,
   $hostname = undef,

--- a/manifests/config/queue.pp
+++ b/manifests/config/queue.pp
@@ -1,19 +1,15 @@
-# Define: qpid::config::queue
-#
 # This define ensures a queue exists
 #
-# === Parameters
-#
-# $queue::                      Name of the queue
-#
-# $hostname::                   Hostname of the qpid broker
-#
-# $port::                       Port that qpid is listening on
-#
-# $ssl_cert::                   SSL cert to use for qpid-config commands
-#
-# $ssl_key::                    SSL key to use for qpid-config commands
-#
+# @param queue
+#   Name of the queue
+# @param hostname
+#   Hostname of the qpid broker
+# @param port
+#   Port that qpid is listening on
+# @param ssl_cert
+#   SSL cert to use for qpid-config commands
+# @param ssl_key
+#   SSL key to use for qpid-config commands
 define qpid::config::queue(
   $queue = $title,
   $hostname = undef,

--- a/manifests/config_cmd.pp
+++ b/manifests/config_cmd.pp
@@ -1,26 +1,21 @@
-# Define: qpid::config_cmd
-#
 # This define wraps the qpid-config command
 #
-# === Parameters
-#
-# $command::                    The qpid-config command including parameters to execute
-#
-# $onlyif::                     The qpid-config command including parameters to
-#                               check if $command should be executed
-#
-# $unless::                     The qpid-config command including parameters to
-#                               check if $command should not be executed.
-#                               Ignored if $onlyif is specified
-#
-# $hostname::                   The hostname to connect to
-#
-# $port::                       Port that qpid is listening on
-#
-# $ssl_cert::                   SSL cert to use for qpid-config commands
-#
-# $ssl_key::                    SSL key to use for qpid-config commands
-#
+# @param command
+#   The qpid-config command including parameters to execute
+# @param onlyif
+#   The qpid-config command including parameters to check if $command should be
+#   executed
+# @param unless
+#   The qpid-config command including parameters to check if $command should
+#   not be executed. Ignored if $onlyif is specified
+# @param hostname
+#   The hostname to connect to
+# @param port
+#   Port that qpid is listening on
+# @param ssl_cert
+#   SSL cert to use for qpid-config commands
+# @param ssl_key
+#   SSL key to use for qpid-config commands
 define qpid::config_cmd (
   $command,
   $onlyif = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::install
-#
 # Handles Qpid install
 #
+# @api private
 class qpid::install {
 
   include qpid::tools

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::params
-#
 # Default parameter values
 #
+# @api private
 class qpid::params {
   $version = 'installed'
   $auth = false

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -1,26 +1,21 @@
-# == Class: qpid::router
-#
 # Handles Qpid dispatch router package installations and configuration
 #
-#
-# == Parameters
-#
-# $router_id::       Unique router ID
-#
-# $mode::            Router mode
-#
-# $config_file::     Dispatch router config file location
-#
-# $open_file_limit:: Limit number of open files - systemd distros only
-#
-# $router_packages:: The package to be installed
-#
-# $worker_threads::  Number of worker threads
-#
-# $hello_interval::  Frequency in seconds of sending heartbeats from this router
-#
-# $hello_max_age::   Timeout of heartbeat before connections are dropped
-#
+# @param router_id
+#   Unique router ID
+# @param mode
+#   Router mode
+# @param config_file
+#   Dispatch router config file location
+# @param router_packages
+#   The package to be installed
+# @param open_file_limit
+#   Limit number of open files - systemd distros only
+# @param worker_threads
+#   Number of worker threads
+# @param hello_interval
+#   Frequency in seconds of sending heartbeats from this router
+# @param hello_max_age
+#   Timeout of heartbeat before connections are dropped
 class qpid::router(
   $router_id               = $qpid::router::params::router_id,
   $mode                    = $qpid::router::params::router_mode,

--- a/manifests/router/config.pp
+++ b/manifests/router/config.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::router::configure
-#
 # Handles Qpid Dispatch Router configuration
 #
+# @api private
 class qpid::router::config {
 
   concat::fragment {'qdrouter+header.conf':

--- a/manifests/router/connector.pp
+++ b/manifests/router/connector.pp
@@ -1,21 +1,17 @@
-# == Define: qpid::router::connector
-#
 # Configure a qpid router connector
 #
-# == Parameters
-#
-# $ssl_profile::    SSL profile to use
-#
-# $host::           Host/address to listen on
-#
-# $port::           Port to listen on
-#
-# $sasl_mech::      SASL mechanism to use
-#
-# $role::           Listener role
-#
-# $idle_timeout::   Timeout in seconds
-#
+# @param host
+#   Host/address to listen on
+# @param port
+#   Port to listen on
+# @param sasl_mech
+#   SASL mechanism to use
+# @param role
+#   Listener role
+# @param ssl_profile
+#   SSL profile to use
+# @param idle_timeout
+#   Timeout in seconds
 define qpid::router::connector(
   String $host = '127.0.0.1',
   Integer[0, 65535] $port = 5672,

--- a/manifests/router/install.pp
+++ b/manifests/router/install.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::router:install
-#
 # Installs Qpid router packages
 #
+# @api private
 class qpid::router::install {
   package { $qpid::router::router_packages:
     ensure => 'installed',

--- a/manifests/router/link_route.pp
+++ b/manifests/router/link_route.pp
@@ -1,15 +1,11 @@
-# == Define: qpid::router::link_route
-#
 # Configure a link route
 #
-# == Parameters
-#
-# $prefix::     Prefix to use
-#
-# $direction::  Direction when using asymmetric routing
-#
-# $connection:: Connector for this link route pattern
-#
+# @param direction
+#   Direction when using asymmetric routing
+# @param prefix
+#   Prefix to use
+# @param connection
+#   Connector for this link route pattern
 define qpid::router::link_route(
   Enum['in', 'out'] $direction,
   String $prefix = 'queue.',

--- a/manifests/router/listener.pp
+++ b/manifests/router/listener.pp
@@ -1,21 +1,17 @@
-# == Define: qpid::router::listener
-#
 # Configure a qpid router listener
 #
-# == Parameters
-#
-# $ssl_profile::    SSL profile to use
-#
-# $host::           Host/address to listen on
-#
-# $port::           Port to listen on
-#
-# $sasl_mech::      SASL mechanism to use
-#
-# $role::           Listener role
-#
-# $idle_timeout::   Timeout in seconds
-#
+# @param ssl_profile
+#   SSL profile to use
+# @param host
+#   Host/address to listen on
+# @param port
+#   Port to listen on
+# @param sasl_mech
+#   SASL mechanism to use
+# @param role
+#   Listener role
+# @param idle_timeout
+#   Timeout in seconds
 define qpid::router::listener(
   Optional[String] $ssl_profile = undef,
   Optional[String] $host = undef,

--- a/manifests/router/log.pp
+++ b/manifests/router/log.pp
@@ -1,21 +1,15 @@
-# == Define: qpid::router::log
-#
 # Configure qpid router logging
 #
-# == Parameters
-#
-# $module::         Logging module to use
-#
-# $level::          Logging level to use (e.g., debug+, info+)
-#
-# $timestamp::      Enable timestamps
-#
-# $output::         Log file location
-#
-# == Advanced
-#
-# $config_file::    The config file to use
-#
+# @param module
+#   Logging module to use
+# @param level
+#   Logging level to use (e.g., debug+, info+)
+# @param timestamp
+#   Enable timestamps
+# @param output
+#   Log file location
+# @param config_file
+#   The config file to use
 define qpid::router::log(
   String $module = 'DEFAULT',
   String $level = 'info+',

--- a/manifests/router/params.pp
+++ b/manifests/router/params.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::router::params
+# Default router parameter values
 #
-# Default parameter values
-#
+# @api private
 class qpid::router::params {
   $config_file         = '/etc/qpid-dispatch/qdrouterd.conf'
   $router_id           = $facts['fqdn']

--- a/manifests/router/service.pp
+++ b/manifests/router/service.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::router::service
-#
 # Handles Qpid Dispatch Router service
 #
+# @api private
 class qpid::router::service {
 
   service { 'qdrouterd':

--- a/manifests/router/ssl_profile.pp
+++ b/manifests/router/ssl_profile.pp
@@ -1,25 +1,20 @@
-# == Define: qpid::router::ssl_profile
-#
 # Configures an SSL profile for Qpid Dispatch Router
 #
-# == Parameters
-#
-# $ca::         Location of CA pem file
-#
-# $cert::       Location of certificate pem file
-#
-# $key::        Location of private key pem file
-#
-# $password::   Password, if required
-#
-# $ciphers::    Enabled ciphers, in OpenSSL format
-#
-# $protocols::  Enabled TLS protocols (e.g. TLSv1.1, TLSv1.2)
-#
-# == Advanced
-#
-# $config_file::    The config file to use
-#
+# @param ca
+#   Location of CA pem file
+# @param cert
+#   Location of certificate pem file
+# @param key
+#   Location of private key pem file
+# @param ciphers
+#   Enabled ciphers, in OpenSSL format
+# @param protocols
+#   Enabled TLS protocols (e.g. TLSv1.1, TLSv1.2)
+# @param password
+#   Password, if required
+# @param config_file
+#   The config file to use. This is an advanced parameter and normally doesn't
+#   need to be set.
 define qpid::router::ssl_profile(
   Stdlib::Absolutepath $ca,
   Stdlib::Absolutepath $cert,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,6 @@
-# == Class: qpid::service
-#
 # Handles Qpid service
 #
+# @api private
 class qpid::service {
 
   service { 'qpidd':


### PR DESCRIPTION
This leaves out init since that actually uses parameter groups and yardoc has no support for this. Should I convert it anyway for a proper reference manual?