### PR TITLE
Fixes #25909 - make qpidd.service wait until the port is open

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,11 +33,9 @@ class qpid::service {
       notify  => Service['qpidd'],
     }
 
-    if (!defined(Package['nc']) and $qpid::ssl) {
-      package { 'nc':
-        ensure => installed,
-        notify => Systemd::Dropin_file['wait-for-port.conf'],
-      }
+    if $qpid::ssl {
+      ensure_packages(['nc'])
+      Package['nc'] -> Systemd::Dropin_file['wait-for-port.conf']
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,6 +27,7 @@ class qpid::service {
     }
 
     systemd::dropin_file { 'wait-for-port.conf':
+      ensure  => bool2str($qpid::ssl, 'present', 'absent'),
       unit    => 'qpidd.service',
       content => template('qpid/wait-for-port.conf.erb'),
       notify  => Service['qpidd'],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,5 +25,11 @@ class qpid::service {
       limits          => $limits,
       notify          => Service['qpidd'],
     }
+
+    systemd::dropin_file { 'wait-for-port.conf':
+      unit    => 'qpidd.service',
+      content => template('qpid/wait-for-port.conf.erb'),
+      notify  => Service['qpidd'],
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,7 +33,7 @@ class qpid::service {
       notify  => Service['qpidd'],
     }
 
-    if ! defined(Package['nc']) {
+    if (!defined(Package['nc']) and $qpid::ssl) {
       package { 'nc':
         ensure => installed,
         notify => Systemd::Dropin_file['wait-for-port.conf'],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,5 +32,12 @@ class qpid::service {
       content => template('qpid/wait-for-port.conf.erb'),
       notify  => Service['qpidd'],
     }
+
+    if ! defined(Package['nc']) {
+      package { 'nc':
+        ensure => installed,
+        notify => Systemd::Dropin_file['wait-for-port.conf'],
+      }
+    }
   }
 }

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -29,7 +29,7 @@ describe 'qpid' do
             .with_ensure('absent')
             .that_notifies('Service[qpidd]')
           is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
-            .with_ensure('present')
+            .with_ensure('absent')
             .that_notifies('Service[qpidd]')
         end
       end
@@ -94,6 +94,9 @@ describe 'qpid' do
         end
 
         it 'should configure systemd to wait for the ssl port to be open' do
+          is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
+            .with_ensure('present')
+            .that_notifies('Service[qpidd]')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
             "ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -31,9 +31,6 @@ describe 'qpid' do
           is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
             .with_ensure('absent')
             .that_notifies('Service[qpidd]')
-          is_expected.to contain_package('nc')
-            .with_ensure('installed')
-            .that_notifies('Systemd::Dropin_file[wait-for-port.conf]')
         end
       end
 
@@ -100,6 +97,9 @@ describe 'qpid' do
           is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
             .with_ensure('present')
             .that_notifies('Service[qpidd]')
+          is_expected.to contain_package('nc')
+            .with_ensure('installed')
+            .that_notifies('Systemd::Dropin_file[wait-for-port.conf]')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
             "ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -28,6 +28,9 @@ describe 'qpid' do
           is_expected.to contain_systemd__service_limits('qpidd.service')
             .with_ensure('absent')
             .that_notifies('Service[qpidd]')
+          is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
+            .with_ensure('present')
+            .that_notifies('Service[qpidd]')
         end
       end
 
@@ -87,6 +90,13 @@ describe 'qpid' do
             'ssl-cert-db=/etc/pki/katello/nssdb',
             'ssl-cert-password-file=/etc/pki/katello/nssdb/nss_db_password-file',
             'ssl-cert-name=broker'
+          ])
+        end
+
+        it 'should configure systemd to wait for the ssl port to be open' do
+          verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
+            "[Service]",
+            "ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"
           ])
         end
       end

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -102,7 +102,7 @@ describe 'qpid' do
             .with_ensure('present')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
-            "ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"
+            "ExecStartPost=/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"
           ])
         end
       end

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -97,9 +97,9 @@ describe 'qpid' do
           is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
             .with_ensure('present')
             .that_notifies('Service[qpidd]')
+            .that_requires('Package[nc]')
           is_expected.to contain_package('nc')
-            .with_ensure('installed')
-            .that_notifies('Systemd::Dropin_file[wait-for-port.conf]')
+            .with_ensure('present')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
             "ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -31,6 +31,9 @@ describe 'qpid' do
           is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
             .with_ensure('absent')
             .that_notifies('Service[qpidd]')
+          is_expected.to contain_package('nc')
+            .with_ensure('installed')
+            .that_notifies('Systemd::Dropin_file[wait-for-port.conf]')
         end
       end
 

--- a/templates/wait-for-port.conf.erb
+++ b/templates/wait-for-port.conf.erb
@@ -1,0 +1,4 @@
+[Service]
+<% if scope['qpid::ssl'] -%>
+ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 <%= scope['qpid::ssl_port'] %>; do sleep 1; done'
+<% end %>

--- a/templates/wait-for-port.conf.erb
+++ b/templates/wait-for-port.conf.erb
@@ -1,4 +1,2 @@
 [Service]
-<% if scope['qpid::ssl'] -%>
 ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 <%= scope['qpid::ssl_port'] %>; do sleep 1; done'
-<% end %>

--- a/templates/wait-for-port.conf.erb
+++ b/templates/wait-for-port.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=-/bin/bash -c 'while ! nc -z 127.0.0.1 <%= scope['qpid::ssl_port'] %>; do sleep 1; done'
+ExecStartPost=/bin/bash -c 'while ! nc -z 127.0.0.1 <%= scope['qpid::ssl_port'] %>; do sleep 1; done'


### PR DESCRIPTION
qpidd does not open the ssl-port immediately after starting, but after
some initialization happened. Let's make qpidd.service not return until
the port is really open, as otherwise actions depending on the service
being available might fail