### PR TITLE
Fixes #25909 - make qpidd.service wait until the port is open

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -26,5 +26,17 @@ class qpid::service {
       limits          => $limits,
       notify          => Service['qpidd'],
     }
+
+    systemd::dropin_file { 'wait-for-port.conf':
+      ensure  => bool2str($qpid::ssl, 'present', 'absent'),
+      unit    => 'qpidd.service',
+      content => template('qpid/wait-for-port.conf.erb'),
+      notify  => Service['qpidd'],
+    }
+
+    if $qpid::ssl {
+      ensure_packages(['nc'])
+      Package['nc'] -> Systemd::Dropin_file['wait-for-port.conf']
+    }
   }
 }

--- a/templates/wait-for-port.conf.erb
+++ b/templates/wait-for-port.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/bin/bash -c 'while ! nc -z 127.0.0.1 <%= scope['qpid::ssl_port'] %>; do sleep 1; done'


### PR DESCRIPTION
qpidd does not open the ssl-port immediately after starting, but after
some initialization happened. Let's make qpidd.service not return until
the port is really open, as otherwise actions depending on the service
being available might fail

(cherry picked from commit 7534cd902129921d5f86722ea9e41df7ff188f52)