### PR TITLE
bump camptocamp/systemd requirement to >= 1.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 0.4.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
we're using `systemd::service_limits` which was introduced in 1.0.0:
* [changelog for 1.0.0](https://github.com/camptocamp/puppet-systemd/blob/master/CHANGELOG.md#100-2017-09-04)
* [commit that added the functionality](https://github.com/camptocamp/puppet-systemd/commit/ec94e54f14c214a5423681e90b99d6e73094bfeb)