### PR TITLE
Refs #26571 - Support ACL file & router auth

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,4 +20,18 @@ class qpid::config
     group   => 'root',
     mode    => '0644',
   }
+
+  if $qpid::acl_content {
+    $acl_file_ensure = file
+  } else {
+    $acl_file_ensure = absent
+  }
+
+  file { $qpid::acl_file:
+    ensure  => $acl_file_ensure,
+    owner   => 'root',
+    group   => 'qpidd',
+    mode    => '0640',
+    content => $qpid::acl_content,
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,10 @@
 #
 # $log_level::                Logging level
 #
+# $acl_file::                 File name for Qpid ACL
+#
+# $acl_content::              Content for Access Control List file
+
 # === SSL parameters
 #
 # $auth::                     Use SASL authentication
@@ -61,6 +65,8 @@ class qpid (
   String $version = $qpid::params::version,
   Boolean $auth = $qpid::params::auth,
   String $config_file = $qpid::params::config_file,
+  Optional[String] $acl_content = $qpid::params::acl_content,
+  String $acl_file = $qpid::params::acl_file,
   String $log_level = $qpid::params::log_level,
   Boolean $log_to_syslog = $qpid::params::log_to_syslog,
   Optional[String] $interface = $qpid::params::interface,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,9 @@ class qpid::params {
   $version = 'installed'
   $auth = false
 
+  $acl_content = undef
+  $acl_file = '/etc/qpid/qpid.acl'
+
   $config_file = '/etc/qpid/qpidd.conf'
 
   $log_level = 'error+'

--- a/manifests/router/connector.pp
+++ b/manifests/router/connector.pp
@@ -6,6 +6,10 @@
 #   Port to listen on
 # @param sasl_mech
 #   SASL mechanism to use
+# @param sasl_username
+#   SASL username
+# @param sasl_password
+#   SASL password
 # @param role
 #   Listener role
 # @param ssl_profile
@@ -16,6 +20,8 @@ define qpid::router::connector(
   String $host = '127.0.0.1',
   Integer[0, 65535] $port = 5672,
   Optional[String] $sasl_mech = 'ANONYMOUS',
+  Optional[String] $sasl_username = undef,
+  Optional[String] $sasl_password = undef,
   Optional[Enum['normal', 'inter-router', 'route-container']] $role = undef,
   Optional[String] $ssl_profile = undef,
   Optional[Integer[0]] $idle_timeout = undef,

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -67,6 +67,30 @@ describe 'qpid' do
         end
       end
 
+      context 'with ACL file' do
+        let :params do
+          super().merge(
+            acl_file: "/etc/qpid/qpid.acl",
+            acl_content: "allow all all"
+          )
+        end
+
+        it 'should create configuration file' do
+          verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'acl-file=/etc/qpid/qpid.acl',
+            'log-enable=error+',
+            'log-to-syslog=yes',
+            'auth=no',
+          ])
+        end
+
+        it 'should create ACL file' do
+          verify_exact_contents(catalogue, '/etc/qpid/qpid.acl', [
+            'allow all all',
+          ])
+        end
+      end
+
       context 'with ssl options' do
         let :params do
           super().merge(

--- a/spec/defines/router_connector_spec.rb
+++ b/spec/defines/router_connector_spec.rb
@@ -9,6 +9,8 @@ describe 'qpid::router::connector' do
       port: 5672,
       role: "inter-router",
       ssl_profile: "router-ssl",
+      sasl_username: "qpid_user",
+      sasl_password: "qpid_password",
       idle_timeout: 0,
       config_file: '/etc/qpid-dispatch/qdrouterd.conf',
     }
@@ -22,6 +24,8 @@ describe 'qpid::router::connector' do
       '    host: 127.0.0.1',
       '    port: 5672',
       '    sasl-mechanisms: ANONYMOUS',
+      '    sasl-username: qpid_user',
+      '    sasl-password: qpid_password',
       '    role: inter-router',
       '    ssl-profile: router-ssl',
       '    idle-timeout-seconds: 0',

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -27,6 +27,9 @@
 # (Note: no spaces on either side of '='). Using default settings:
 # "qpidd --help" or "man qpidd" for more details.
 #cluster-mechanism=ANONYMOUS
+<% unless [nil, :undefined, :undef, ''].include?(scope['qpid::acl_content']) -%>
+acl-file=<%= scope['qpid::acl_file'] %>
+<% end %>
 log-enable=<%= scope['qpid::log_level'] %>
 log-to-syslog=<%= scope['qpid::log_to_syslog'] ? 'yes' : 'no' %>
 auth=<%= scope['qpid::auth'] ? 'yes' : 'no' %>

--- a/templates/router/connector.conf.erb
+++ b/templates/router/connector.conf.erb
@@ -3,6 +3,12 @@ connector {
     host: <%= @host %>
     port: <%= @port %>
     sasl-mechanisms: <%= @sasl_mech %>
+<% unless [nil, :undefined, :undef, ''].include?(@sasl_username) -%>
+    sasl-username: <%= @sasl_username %>
+<% end -%>
+<% unless [nil, :undefined, :undef, ''].include?(@sasl_password) -%>
+    sasl-password: <%= @sasl_password %>
+<% end -%>
 <% unless [nil, :undefined, :undef, ''].include?(@role) -%>
     role: <%= @role %>
 <% end -%>


### PR DESCRIPTION
Consider testing in conjunction with:

https://github.com/theforeman/puppet-katello/pull/283
https://github.com/theforeman/puppet-foreman_proxy_content/pull/197

To test (assumes forklifted dev env):

- follow forklift docs (https://github.com/theforeman/forklift/blob/master/docs/development.md#test-puppet-module-pull-requests) to test the linked PRs
- 'vagrant provision centos7-katello-devel'
- verify that /etc/qpid/qpid.acl is populated according to the PR
- verify that /etc/qpid-dispatch/qdrouter.conf "connector" has sasl-mechanism PLAIN, sasl-username katello_agent and sasl-password that resembles a password
- verify that services qpidd and qdrouterd are running properly
- register a client, verify that package actions can be performed as usual via katello-agent

scripts should not be able to perform the actions in the ACL file. Here's an example which attempts to list queues:

```
from proton import Message, SSLDomain, SSLException
from proton.reactor import DynamicNodeProperties
from proton.utils import BlockingConnection
from uuid import uuid4
from gofer.config import Config

QMF_SUBJECT = 'broker'
RHSM_CONFIG_PATH = '/etc/rhsm/rhsm.conf'

domain = SSLDomain(SSLDomain.MODE_CLIENT)
domain.set_trusted_ca_db('/etc/rhsm/ca/katello-server-ca.pem')
domain.set_credentials('/etc/pki/consumer/bundle.pem', '/etc/pki/consumer/bundle.pem', None)
domain.set_peer_authentication(SSLDomain.VERIFY_PEER)

rhsm_conf = Config(RHSM_CONFIG_PATH)
ROUTER_ADDRESS = 'proton+amqps://%s:5647' % rhsm_conf['server']['hostname']

def qmf_properties(opcode):
    return {
        'qmf.opcode': opcode,
        'x-amqp-0-10.app-id': 'qmf2'
    }

def qmf_query_body():
    return {
        '_what': 'OBJECT',
        '_schema_id': { '_class_name': 'queue' }
    }


qmf_conn = BlockingConnection(ROUTER_ADDRESS, ssl_domain=domain, heartbeat=10)
qmf_rec = qmf_conn.create_receiver(None, name=str(uuid4()), dynamic=True, options=DynamicNodeProperties({'x-opt-qd.address': unicode("qmf.default.direct")}))
qmf_snd = qmf_conn.create_sender("qmf.default.direct", name=str(uuid4()))


# query for list all queues
request = Message(
    body=qmf_query_body(),
    reply_to=qmf_rec.remote_source.address,
    properties=qmf_properties('_query_request'),
    correlation_id=str(uuid4()),
    subject=QMF_SUBJECT
)
qmf_snd.send(request)
reply = qmf_rec.receive()
print(reply)

```