### PR TITLE
Drop python2-qpid as a server package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class qpid::params {
   $user = 'qpidd'
   $group = 'qpidd'
 
-  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python2-qpid']
+  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client']
 
   $server_store = true
   $server_store_package = 'qpid-cpp-server-linearstore'


### PR DESCRIPTION
This is typically needed by service interacting with qpidd and not
qpidd itself.

@ekohl you were right :)