### PR TITLE
Allow `puppetlabs/stdlib`  and `puppetlabs/concat` 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0 < 6.0.0"
+      "version_requirement": ">= 4.18.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 < 6.0.0"
+      "version_requirement": ">= 1.0.0 < 7.0.0"
     },
     {
       "name": "camptocamp/systemd",


### PR DESCRIPTION
stdlib 6.0.0 is due to be released soon.
This module has already dropped support for puppet 4.

See
https://github.com/puppetlabs/puppetlabs-stdlib/blob/217068f97edd2396ce37ac8c1bd7e23da621d6be/CHANGELOG.md#supported-release-600