### PR TITLE
Fixes #28672 - Check if qpid is up using localhost

### DIFF
--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -126,7 +126,7 @@ describe 'qpid' do
             .with_ensure('present')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
-            "ExecStartPost=/bin/bash -c 'while ! nc -z 127.0.0.1 5671; do sleep 1; done'"
+            "ExecStartPost=/bin/bash -c 'while ! nc -z localhost 5671; do sleep 1; done'"
           ])
         end
       end

--- a/templates/wait-for-port.conf.erb
+++ b/templates/wait-for-port.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=/bin/bash -c 'while ! nc -z 127.0.0.1 <%= scope['qpid::ssl_port'] %>; do sleep 1; done'
+ExecStartPost=/bin/bash -c 'while ! nc -z localhost <%= scope['qpid::ssl_port'] %>; do sleep 1; done'


### PR DESCRIPTION
Given a machine that has 127.0.0.1 / ::1 on lo and eth0 has 2001:db::1, in other works, no IPv4 connectivity, then qpid qpid binds only on IPv6, even when a host needs to listen on localhost. Since netcat can connect to either, it is a safe check.

@adamruzicka this is currently a draft since I haven't tested this yet. Could you give this a spin in your setup?