### PR TITLE
Fixes #30252: Make wait for port more resilient

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -34,8 +34,8 @@ class qpid::service {
     }
 
     if $qpid::ssl {
-      ensure_packages(['nc'])
-      Package['nc'] -> Systemd::Dropin_file['wait-for-port.conf']
+      ensure_packages(['iproute'])
+      Package['iproute'] -> Systemd::Dropin_file['wait-for-port.conf']
     }
   }
 }

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -121,12 +121,12 @@ describe 'qpid' do
           is_expected.to contain_systemd__dropin_file('wait-for-port.conf')
             .with_ensure('present')
             .that_notifies('Service[qpidd]')
-            .that_requires('Package[nc]')
-          is_expected.to contain_package('nc')
+            .that_requires('Package[iproute]')
+          is_expected.to contain_package('iproute')
             .with_ensure('present')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
-            "ExecStartPost=/bin/bash -c 'while ! nc -z localhost 5671; do sleep 1; done'"
+            "ExecStartPost=/bin/bash -c 'while ! ss --no-header --tcp --listening --numeric sport = :5671 | grep -q \"^LISTEN.*:5671\"; do sleep 1; done'"
           ])
         end
       end

--- a/templates/wait-for-port.conf.erb
+++ b/templates/wait-for-port.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=/bin/bash -c 'while ! nc -z localhost <%= scope['qpid::ssl_port'] %>; do sleep 1; done'
+ExecStartPost=/bin/bash -c 'while ! ss --no-header --tcp --listening --numeric sport = :<%= scope['qpid::ssl_port'] %> | grep -q "^LISTEN.*:<%= scope['qpid::ssl_port'] %>"; do sleep 1; done'


### PR DESCRIPTION
The current method can result in journal error messages:

[System] error Error reading socket: Encountered end of file [-5938]

This updated version waits and checks for listening ports
and greps for the port in question to appear before signaling
that the service is ready.