### PR TITLE
Bump master to 7.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-qpid",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "author": "katello",
   "summary": "Qpid message bus configuration",
   "license": "GPL-3.0+",


### PR DESCRIPTION
There was a breaking change but also a 6.2.0 release. It's confusing to have an older version than what's actually released.