### PR TITLE
Release 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [7.0.0](https://github.com/theforeman/puppet-qpid/tree/7.0.0) (2021-03-01)
+
+[Full Changelog](https://github.com/theforeman/puppet-qpid/compare/6.2.0...7.0.0)
+
+**Breaking changes:**
+
+- Use modern facts [\#134](https://github.com/theforeman/puppet-qpid/issues/134)
+
+**Implemented enhancements:**
+
+- Expose username and sasl\_mechanism options in config\_cmd [\#145](https://github.com/theforeman/puppet-qpid/pull/145) ([ekohl](https://github.com/ekohl))
+
+## [6.2.0](https://github.com/theforeman/puppet-qpid/tree/6.2.0) (2020-11-30)
+
+[Full Changelog](https://github.com/theforeman/puppet-qpid/compare/6.1.0...6.2.0)
+
+**Implemented enhancements:**
+
+- Fixes [\#30252](https://projects.theforeman.org/issues/30252): Make wait for port more resilient [\#137](https://github.com/theforeman/puppet-qpid/pull/137) ([ehelms](https://github.com/ehelms))
+
 ## [6.1.0](https://github.com/theforeman/puppet-qpid/tree/6.1.0) (2020-02-11)
 
 [Full Changelog](https://github.com/theforeman/puppet-qpid/compare/6.0.0...6.1.0)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,31 @@
+## [7.0.0](https://github.com/theforeman/puppet-qpid/tree/7.0.0) (2021-03-01)
+
+[Full Changelog](https://github.com/theforeman/puppet-qpid/compare/6.2.0...7.0.0)
+
+**Breaking changes:**
+
+- Use modern facts [\#134](https://github.com/theforeman/puppet-qpid/issues/134)
+
+**Implemented enhancements:**
+
+- Expose username and sasl\_mechanism options in config\_cmd [\#145](https://github.com/theforeman/puppet-qpid/pull/145) ([ekohl](https://github.com/ekohl))
+
+## [6.2.0](https://github.com/theforeman/puppet-qpid/tree/6.2.0) (2020-11-30)
+
+[Full Changelog](https://github.com/theforeman/puppet-qpid/compare/6.1.0...6.2.0)
+
+**Implemented enhancements:**
+
+- Fixes [\#30252](https://projects.theforeman.org/issues/30252): Make wait for port more resilient [\#137](https://github.com/theforeman/puppet-qpid/pull/137) ([ehelms](https://github.com/ehelms))
+
+## [6.1.0](https://github.com/theforeman/puppet-qpid/tree/6.1.0) (2020-02-11)
+
+[Full Changelog](https://github.com/theforeman/puppet-qpid/compare/6.0.0...6.1.0)
+
+**Implemented enhancements:**
+
+- Fixes [\#28672](https://projects.theforeman.org/issues/28672) - Check if qpid is up using localhost [\#128](https://github.com/theforeman/puppet-qpid/pull/128) ([ekohl](https://github.com/ekohl))
+
 ## [6.0.0](https://github.com/theforeman/puppet-qpid/tree/6.0.0) (2019-05-31)
 
 [Full Changelog](https://github.com/theforeman/puppet-qpid/compare/5.0.0...6.0.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-qpid",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "author": "katello",
   "summary": "Qpid message bus configuration",
   "license": "GPL-3.0+",


### PR DESCRIPTION
This removes some of the confusing parts of this module, like we have a 6.2-stable branch that's essentially ahead of this module. It'll be a bit painful to update all modules to allow this new release but in the end it'll be clearer when we can use master as a development branch.