### PR TITLE
Install cyrus-sasl-plain package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,10 @@ class qpid::install {
     before => Class['qpid::tools'],
   }
 
+  if $qpid::auth {
+    ensure_packages(['cyrus-sasl-plain'])
+  }
+
   if $qpid::server_store {
     package { $qpid::server_store_package:
       ensure => $qpid::version,

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -219,6 +219,21 @@ describe 'qpid' do
           ])
         end
       end
+
+      context 'with auth' do
+        let(:params) { super().merge(auth: true) }
+
+        it 'should create configuration file' do
+          verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'log-enable=error+',
+            'log-to-syslog=yes',
+            'auth=yes',
+          ])
+        end
+        it 'should install cyrus-sasl-plain' do
+          is_expected.to contain_package('cyrus-sasl-plain')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Given the SASL mechanisms used, the cyrus-sasl-plain package is
needed to support them.

This allows us to remove this requirement from the katello package spec file and localize it with the code that needs it. This further helps when we make katello-agent infrastructure optional as we will only install this package when its needed.