### PR TITLE
Remove duplicate relations

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,18 +2,17 @@
 #
 # @api private
 class qpid::install {
-
   include qpid::tools
 
   package { $qpid::server_packages:
     ensure => $qpid::version,
-    before => [Service['qpidd'],Package['qpid-tools']],
+    before => Class['qpid::tools'],
   }
 
   if $qpid::server_store {
     package { $qpid::server_store_package:
       ensure => $qpid::version,
-      before => [Service['qpidd'],Package['qpid-tools']],
+      before => Class['qpid::tools'],
     }
   }
 }

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -12,6 +12,7 @@ describe 'qpid' do
         it { is_expected.to contain_class('qpid::install') }
         it 'should install message store by default' do
           is_expected.to contain_package('qpid-cpp-server-linearstore')
+            .that_comes_before(['Service[qpidd]', 'Package[qpid-tools]'])
         end
 
         it { is_expected.to contain_class('qpid::config') }


### PR DESCRIPTION
The qpidd service relation is already set in init.pp. The direct package resource is replaced with the class that encapsulates it.