### PR TITLE
Router template should use mode and not router_mode

### DIFF
--- a/spec/classes/qpid_router_spec.rb
+++ b/spec/classes/qpid_router_spec.rb
@@ -116,6 +116,24 @@ describe 'qpid::router' do
             .with_limits({'LimitNOFILE' => 10000})
         end
       end
+
+      context 'should allow setting router mode' do
+        let :params do
+          {
+            mode: 'standalone',
+          }
+        end
+
+        it 'should have header fragment' do
+          verify_concat_fragment_exact_contents(catalogue, 'qdrouter+header.conf', [
+            'router {',
+            '    id: foo.example.com',
+            '    mode: standalone',
+            '    worker-threads: 2',
+            '}'
+          ])
+        end
+      end
     end
   end
 end

--- a/templates/router/header.conf.erb
+++ b/templates/router/header.conf.erb
@@ -22,7 +22,7 @@
 
 router {
     id: <%= scope['qpid::router::router_id'] %>
-    mode: <%= scope['qpid::router::router_mode'] %>
+    mode: <%= scope['qpid::router::mode'] %>
     worker-threads: <%= scope['qpid::router::worker_threads'] %>
 <% unless [nil, :undefined, :undef, ''].include?(scope['qpid::router::hello_interval']) -%>
     helloInterval: <%= scope['qpid::router::hello_interval'] %>


### PR DESCRIPTION
The header.conf.erb template was referencing router_mode instead
of the 'mode' parameter which can be set by users. Therefore the
mode could never actually be configured by a user and the default
in params.pp was always used.