### PR TITLE
Refs #32037: Add ensure on qpid class to allow removal of all qpid as…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,24 +4,24 @@
 class qpid::config
 {
 
-  group { $qpid::group:
-    ensure => present,
-  }
-
   user { $qpid::user:
-    ensure => present,
+    ensure => $qpid::ensure,
     groups => $qpid::user_groups,
   }
 
+  group { $qpid::group:
+    ensure => $qpid::ensure,
+  }
+
   file { $qpid::config_file:
-    ensure  => file,
+    ensure  => $qpid::ensure,
     content => template('qpid/qpidd.conf.erb'),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
   }
 
-  if $qpid::acl_content {
+  if $qpid::acl_content and $qpid::ensure == 'present' {
     $acl_file_ensure = file
   } else {
     $acl_file_ensure = absent

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,8 @@
 #
 # $service_enable::           Enable qpidd service at boot
 #
+# $ensure::                   Specify to explicitly enable Qpid installs or absent to remove all packages and configs
+#
 class qpid (
   String $version = $qpid::params::version,
   Boolean $auth = $qpid::params::auth,
@@ -93,6 +95,7 @@ class qpid (
   Hash[String, Variant[String, Integer]] $custom_settings = $qpid::params::custom_settings,
   Boolean $service_ensure = true,
   Optional[Boolean] $service_enable = undef,
+  Enum['present', 'absent'] $ensure = 'present',
 ) inherits qpid::params {
   if $ssl {
     assert_type(Boolean, $ssl_require_client_auth)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,21 +2,24 @@
 #
 # @api private
 class qpid::install {
-  include qpid::tools
+
+  if $qpid::ensure == 'absent' {
+    $_package_ensure = 'purged'
+  } else {
+    $_package_ensure = $qpid::version
+  }
 
   package { $qpid::server_packages:
-    ensure => $qpid::version,
-    before => Class['qpid::tools'],
+    ensure => $_package_ensure,
   }
 
   if $qpid::auth {
-    ensure_packages(['cyrus-sasl-plain'])
+    ensure_packages(['cyrus-sasl-plain'], {ensure => $_package_ensure})
   }
 
   if $qpid::server_store {
     package { $qpid::server_store_package:
-      ensure => $qpid::version,
-      before => Class['qpid::tools'],
+      ensure => $_package_ensure,
     }
   }
 }

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -20,6 +20,9 @@
 #   Enable/disable qdrouterd service at boot
 # @param service_ensure
 #   Specify if qdrouterd should be running or stopped.
+# @param ensure
+#   Specify to explicitly enable Qpid Dispatch installs or absent to remove all packages and configs
+#
 class qpid::router(
   String $router_id = $qpid::router::params::router_id,
   String $mode = 'interior',
@@ -31,6 +34,7 @@ class qpid::router(
   Optional[Integer] $hello_max_age = undef,
   Boolean $service_ensure = true,
   Optional[Boolean] $service_enable = undef,
+  Enum['present', 'absent'] $ensure = 'present',
 ) inherits qpid::router::params {
 
   contain qpid::router::install

--- a/manifests/router/config.pp
+++ b/manifests/router/config.pp
@@ -16,9 +16,10 @@ class qpid::router::config {
   }
 
   concat { $qpid::router::config_file:
-    owner => 'root',
-    group => 'root',
-    mode  => '0644',
+    ensure => $qpid::router::ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 
   Concat::Fragment<| target == $qpid::router::config_file |> ~> Concat[$qpid::router::config_file]

--- a/manifests/router/install.pp
+++ b/manifests/router/install.pp
@@ -2,7 +2,14 @@
 #
 # @api private
 class qpid::router::install {
+
+  if $qpid::router::ensure == 'absent' {
+    $_package_ensure = 'purged'
+  } else {
+    $_package_ensure = 'installed'
+  }
+
   package { $qpid::router::router_packages:
-    ensure => 'installed',
+    ensure => $_package_ensure,
   }
 }

--- a/manifests/router/service.pp
+++ b/manifests/router/service.pp
@@ -3,15 +3,23 @@
 # @api private
 class qpid::router::service {
 
+  if $qpid::router::ensure == 'absent' {
+    $_service_ensure = false
+    $_service_enable = false
+  } else {
+    $_service_ensure = $qpid::router::service_ensure
+    $_service_enable = $qpid::router::service_enable
+  }
+
   service { 'qdrouterd':
-    ensure     => $qpid::router::service_ensure,
-    enable     => pick($qpid::router::service_enable, $qpid::router::service_ensure),
+    ensure     => $_service_ensure,
+    enable     => pick($_service_enable, $_service_ensure),
     hasstatus  => true,
     hasrestart => true,
   }
 
   if $facts['systemd'] {
-    if $qpid::router::open_file_limit {
+    if $qpid::router::open_file_limit and $qpid::router::ensure {
       $ensure_limit = 'present'
       $limits = {'LimitNOFILE' => $qpid::router::open_file_limit}
     } else {

--- a/spec/acceptance/qpid_router_spec.rb
+++ b/spec/acceptance/qpid_router_spec.rb
@@ -19,4 +19,25 @@ describe 'qpid::router' do
       it { is_expected.to be_installed }
     end
   end
+
+  context 'with ensure absent' do
+    let(:pp) do
+      <<-PUPPET
+      class { 'qpid::router':
+        ensure => 'absent',
+      }
+      PUPPET
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe service('qdrouterd') do
+      it { is_expected.not_to be_running }
+      it { is_expected.not_to be_enabled }
+    end
+
+    describe package('qpid-dispatch-router') do
+      it { is_expected.not_to be_installed }
+    end
+  end
 end

--- a/spec/acceptance/qpid_spec.rb
+++ b/spec/acceptance/qpid_spec.rb
@@ -19,4 +19,25 @@ describe 'qpid' do
       it { is_expected.to be_listening }
     end
   end
+
+  context 'with ensure absent' do
+    let(:pp) do
+      <<-PUPPET
+      class { 'qpid':
+        ensure => 'absent',
+      }
+      PUPPET
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe service('qpidd') do
+      it { is_expected.not_to be_running }
+      it { is_expected.not_to be_enabled }
+    end
+
+    describe port('5672') do
+      it { is_expected.not_to be_listening }
+    end
+  end
 end

--- a/spec/acceptance/qpid_tool_spec.rb
+++ b/spec/acceptance/qpid_tool_spec.rb
@@ -14,4 +14,28 @@ describe 'qpid::tools' do
       it { is_expected.to be_installed }
     end
   end
+
+  context 'installing qpid' do
+    let(:pp) do
+      <<-PUPPET
+      class { 'qpid::tools': } ->
+      class { 'qpid': }
+      PUPPET
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe package('qpid-tools') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('qpidd') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe port('5672') do
+      it { is_expected.to be_listening }
+    end
+  end
 end

--- a/spec/classes/qpid_router_spec.rb
+++ b/spec/classes/qpid_router_spec.rb
@@ -66,6 +66,30 @@ describe 'qpid::router' do
         end
       end
 
+      context 'with ensure absent' do
+        let(:params) do
+          {
+            ensure: 'absent'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_class('qpid::router::install') }
+        it { is_expected.to contain_package('qpid-dispatch-router').with_ensure('purged') }
+
+        it { is_expected.to contain_class('qpid::router::config') }
+        it { is_expected.to contain_concat('/etc/qpid-dispatch/qdrouterd.conf').with_ensure('absent') }
+
+        it { is_expected.to contain_class('qpid::router::service') }
+        it { is_expected.to contain_systemd__service_limits('qdrouterd.service').with_ensure('absent') }
+        it 'should disable qdrouterd' do
+          is_expected.to contain_service('qdrouterd')
+            .with_ensure('false')
+            .with_enable('false')
+        end
+      end
+
       context 'with services stopped' do
         let(:params) do
           {


### PR DESCRIPTION
…sets

Adds an ensure parameter at the top level to allow specifyin 'absent'
to remove all packages, configuration files and disable services.

I have only done the qpidd part so far (will do qpid-dispatch after discussion) to allow for discussion of design and how far to take this. I have added some basic acceptance tests which will fail and illuminate some of the challenges with doing absent on the package side of things when dependencies are involved.