### PR TITLE
Use correct powertools repository in acceptance tests on older Centos8

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -3,7 +3,13 @@ if $facts['os']['release']['major'] == '8' {
     ensure => installed,
   }
 
-  yumrepo { 'powertools':
+  # See https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes
+  if $facts['os']['release']['minor'] >= '3' {
+    $powertools_repo = 'powertools'
+  } else {
+    $powertools_repo = 'PowerTools'
+  }
+  yumrepo { $powertools_repo:
     enabled => true,
   }
 


### PR DESCRIPTION
When I run the EL8 acceptance tests locally, `qpid-cpp-server-linearstore` will fail to install due to missing dependency on `libdb-cxx`. This is because my environment defaults to an older Centos8 box where the name of the repository had not yet changed.