### PR TITLE
Refs #32037: Do not remove all packages when ensuring absent

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,8 +7,7 @@ class qpid::config
   user { $qpid::user:
     ensure => $qpid::ensure,
     groups => $qpid::user_groups,
-  }
-
+  } ~>
   group { $qpid::group:
     ensure => $qpid::ensure,
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,8 +13,8 @@ class qpid::install {
     ensure => $_package_ensure,
   }
 
-  if $qpid::auth {
-    ensure_packages(['cyrus-sasl-plain'], {ensure => $_package_ensure})
+  if $qpid::auth and $qpid::ensure == 'present' {
+    ensure_packages(['cyrus-sasl-plain'])
   }
 
   if $qpid::server_store {

--- a/manifests/router/service.pp
+++ b/manifests/router/service.pp
@@ -19,7 +19,7 @@ class qpid::router::service {
   }
 
   if $facts['systemd'] {
-    if $qpid::router::open_file_limit and $qpid::router::ensure {
+    if $qpid::router::open_file_limit and $qpid::router::ensure == 'present' {
       $ensure_limit = 'present'
       $limits = {'LimitNOFILE' => $qpid::router::open_file_limit}
     } else {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -47,8 +47,8 @@ class qpid::service {
       notify  => Service['qpidd'],
     }
 
-    if $qpid::ssl {
-      ensure_packages(['iproute'], {ensure => $qpid::ensure})
+    if $qpid::ssl and $qpid::ensure == 'present' {
+      ensure_packages(['iproute'])
       Package['iproute'] -> Systemd::Dropin_file['wait-for-port.conf']
     }
   }

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -56,7 +56,7 @@ describe 'qpid' do
         it { is_expected.to contain_package('qpid-cpp-server').with_ensure('purged') }
         it { is_expected.to contain_package('qpid-cpp-client').with_ensure('purged') }
         it { is_expected.to contain_package('qpid-cpp-server-linearstore').with_ensure('purged') }
-        it { is_expected.to contain_package('cyrus-sasl-plain').with_ensure('purged') }
+        it { is_expected.not_to contain_package('cyrus-sasl-plain') }
 
         it { is_expected.to contain_class('qpid::config') }
         it { is_expected.to contain_group('qpidd').with_ensure('absent') }
@@ -67,7 +67,7 @@ describe 'qpid' do
         it { is_expected.to contain_class('qpid::service') }
         it { is_expected.to contain_systemd__dropin_file('wait-for-port.conf').with_ensure('absent') }
         it { is_expected.to contain_systemd__service_limits('qpidd.service').with_ensure('absent') }
-        it { is_expected.to contain_package('iproute').with_ensure('absent') }
+        it { is_expected.not_to contain_package('iproute') }
         it 'should disable qpidd' do
           is_expected.to contain_service('qpidd')
             .with_ensure('false')


### PR DESCRIPTION
Addresses feedback from previous commit 734b44b8dd2061743f0b12695482ac691682deb5
to not remove ancillary packages and ensure relationship between user
and group.

Attempts to address feedback from https://github.com/theforeman/puppet-qpid/pull/154. This does not currently address https://github.com/theforeman/puppet-qpid/pull/154#discussion_r607744116 as there is discussion around it.