### PR TITLE
Drop Package['qpit-tools'] -> Package['qpid-cpp-server'] test case

### DIFF
--- a/spec/acceptance/qpid_tool_spec.rb
+++ b/spec/acceptance/qpid_tool_spec.rb
@@ -14,28 +14,4 @@ describe 'qpid::tools' do
       it { is_expected.to be_installed }
     end
   end
-
-  context 'installing qpid' do
-    let(:pp) do
-      <<-PUPPET
-      class { 'qpid::tools': } ->
-      class { 'qpid': }
-      PUPPET
-    end
-
-    it_behaves_like 'a idempotent resource'
-
-    describe package('qpid-tools') do
-      it { is_expected.to be_installed }
-    end
-
-    describe service('qpidd') do
-      it { is_expected.to be_running }
-      it { is_expected.to be_enabled }
-    end
-
-    describe port('5672') do
-      it { is_expected.to be_listening }
-    end
-  end
 end


### PR DESCRIPTION
With 734b44 we added this regression test for an old issue where qpid-tools installed
compat-qpid-cpp-client that blocked other package installs. After further discussion
we decided this test no longer makes sense to keep around.