### PR TITLE
Refs #32037: Manage /var/lib/qpidd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,4 +33,12 @@ class qpid::config
     mode    => '0640',
     content => $qpid::acl_content,
   }
+
+  file { $qpid::data_dir:
+    ensure => bool2str($qpid::ensure == 'present', 'directory', $qpid::ensure),
+    owner  => $qpid::user,
+    group  => $qpid::group,
+    mode   => '0755',
+    force  => true,
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,8 @@
 #
 # $ensure::                   Specify to explicitly enable Qpid installs or absent to remove all packages and configs
 #
+# $data_dir::     Location on disk that qpid broker data is stored
+#
 class qpid (
   String $version = $qpid::params::version,
   Boolean $auth = $qpid::params::auth,
@@ -96,6 +98,7 @@ class qpid (
   Boolean $service_ensure = true,
   Optional[Boolean] $service_enable = undef,
   Enum['present', 'absent'] $ensure = 'present',
+  Stdlib::AbsolutePath $data_dir = '/var/lib/qpidd',
 ) inherits qpid::params {
   if $ssl {
     assert_type(Boolean, $ssl_require_client_auth)

--- a/spec/acceptance/qpid_spec.rb
+++ b/spec/acceptance/qpid_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'qpid' do
+describe 'qpid', :order => :defined do
   context 'with default parameters' do
     let(:pp) do
       <<-PUPPET
@@ -21,6 +21,10 @@ describe 'qpid' do
 
     describe package('qpid-tools') do
       it { is_expected.to be_installed }
+    end
+
+    describe file('/var/lib/qpidd') do
+      it { is_expected.to be_directory }
     end
   end
 
@@ -46,6 +50,10 @@ describe 'qpid' do
 
     describe package('qpid-tools') do
       it { is_expected.not_to be_installed }
+    end
+
+    describe file('/var/lib/qpidd') do
+      it { is_expected.not_to exist }
     end
   end
 end

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -18,6 +18,7 @@ describe 'qpid' do
         it { is_expected.to contain_class('qpid::config') }
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no'
@@ -64,6 +65,7 @@ describe 'qpid' do
         it { is_expected.to contain_user('qpidd').with_ensure('absent') }
         it { is_expected.to contain_file('/etc/qpid/qpidd.conf').with_ensure('absent') }
         it { is_expected.to contain_file('/etc/qpid/qpid.acl').with_ensure('absent') }
+        it { is_expected.to contain_file('/var/lib/qpidd').with_ensure('absent') }
 
         it { is_expected.to contain_class('qpid::service') }
         it { is_expected.to contain_systemd__dropin_file('wait-for-port.conf').with_ensure('absent') }
@@ -113,6 +115,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -132,6 +135,7 @@ describe 'qpid' do
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
             'acl-file=/etc/qpid/qpid.acl',
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -159,6 +163,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -190,6 +195,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -203,6 +209,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -216,6 +223,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -229,6 +237,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -251,6 +260,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -265,6 +275,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=no',
@@ -278,6 +289,7 @@ describe 'qpid' do
 
         it 'should create configuration file' do
           verify_exact_contents(catalogue, '/etc/qpid/qpidd.conf', [
+            'data-dir=/var/lib/qpidd',
             'log-enable=error+',
             'log-to-syslog=yes',
             'auth=yes',

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -30,6 +30,7 @@
 <% unless [nil, :undefined, :undef, ''].include?(scope['qpid::acl_content']) -%>
 acl-file=<%= scope['qpid::acl_file'] %>
 <% end %>
+data-dir=<%= scope['qpid::data_dir'] %>
 log-enable=<%= scope['qpid::log_level'] %>
 log-to-syslog=<%= scope['qpid::log_to_syslog'] ? 'yes' : 'no' %>
 auth=<%= scope['qpid::auth'] ? 'yes' : 'no' %>


### PR DESCRIPTION
When the qpidd service starts it creates a directory /var/lib/qpidd/.qpidd
If the qpid is then ensured to be absent, removing the qpidd user
and then re-enabled this directory will have the wrong user id set on it
and get permission denied when trying to start the service.