### PR TITLE
Fix qpid-dispatch parameter deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 
 This module is designed to install and configure Qpid servers, clients, and dispatch routers for communication across a message bus.
 
+## Supported Versions
+
+The following versions of the qpid-cpp and qpid-dispatch are supported by this module
+
+ * qpid-dispatch 1.1.0+
+ * qpid-cpp 1.35+
+
 ## What qpid affects
 
 * Installs and configures a Qpid server, client, or dispatch router

--- a/spec/defines/router_link_route_spec.rb
+++ b/spec/defines/router_link_route_spec.rb
@@ -17,7 +17,7 @@ describe 'qpid::router::link_route' do
     verify_concat_fragment_exact_contents(catalogue, 'qdrouter+link_route_broker-link.conf', [
       'linkRoute {',
       '    prefix: unicorn.',
-      '    dir: in',
+      '    direction: in',
       '    connection: broker',
       '}'
     ])

--- a/spec/defines/router_log_spec.rb
+++ b/spec/defines/router_log_spec.rb
@@ -17,8 +17,8 @@ describe 'qpid::router::log' do
           'log {',
           '    module: DEFAULT',
           '    enable: info+',
-          '    timestamp: true',
-          '    output: /var/log/qdrouterd.log',
+          '    include-timestamp: true',
+          '    output-file: /var/log/qdrouterd.log',
           '}',
         ])
       end
@@ -39,8 +39,8 @@ describe 'qpid::router::log' do
           'log {',
           '    module: DEFAULT',
           '    enable: debug+',
-          '    timestamp: false',
-          '    output: /var/log/qpid.log',
+          '    include-timestamp: false',
+          '    output-file: /var/log/qpid.log',
           '}'
         ])
       end
@@ -61,8 +61,8 @@ describe 'qpid::router::log' do
           'log {',
           '    module: DEFAULT',
           '    enable: debug+',
-          '    timestamp: false',
-          '    output: syslog',
+          '    include-timestamp: false',
+          '    output-file: syslog',
           '}'
         ])
       end
@@ -82,8 +82,8 @@ describe 'qpid::router::log' do
             'log {',
             '    module: DEFAULT',
             '    enable: info+',
-            '    timestamp: true',
-            '    output: /var/log/qdrouterd.log',
+            '    include-timestamp: true',
+            '    output-file: /var/log/qdrouterd.log',
             '}',
           ])
         end

--- a/spec/defines/router_ssl_profile_spec.rb
+++ b/spec/defines/router_ssl_profile_spec.rb
@@ -23,9 +23,9 @@ describe 'qpid::router::ssl_profile' do
       verify_concat_fragment_exact_contents(catalogue, 'qdrouter+ssl_example.conf', [
         'ssl-profile {',
         '    name: example',
-        '    cert-db: /ca.pem',
+        '    ca-cert-file: /ca.pem',
         '    cert-file: /cert.pem',
-        '    key-file: /key.pem',
+        '    private-key-file: /key.pem',
         '}',
       ])
     end
@@ -47,9 +47,9 @@ describe 'qpid::router::ssl_profile' do
       verify_concat_fragment_exact_contents(catalogue, 'qdrouter+ssl_example.conf', [
         'ssl-profile {',
         '    name: example',
-        '    cert-db: /some/where/ca.pem',
+        '    ca-cert-file: /some/where/ca.pem',
         '    cert-file: /some/where/cert.pem',
-        '    key-file: /some/where/key.pem',
+        '    private-key-file: /some/where/key.pem',
         '    ciphers: ALL:!aNULL:!MD5:!DSS',
         '    protocols: TLSv1.1 TLSv1.2',
         '}'
@@ -72,9 +72,9 @@ describe 'qpid::router::ssl_profile' do
       verify_concat_fragment_exact_contents(catalogue, 'qdrouter+ssl_example.conf', [
         'ssl-profile {',
         '    name: example',
-        '    cert-db: /ca.pem',
+        '    ca-cert-file: /ca.pem',
         '    cert-file: /cert.pem',
-        '    key-file: /key.pem',
+        '    private-key-file: /key.pem',
         '    password: secret',
         '}',
       ])

--- a/templates/router/link_route.conf.erb
+++ b/templates/router/link_route.conf.erb
@@ -1,7 +1,7 @@
 linkRoute {
     prefix: <%= @prefix %>
 <% unless [nil, :undefined, :undef, ''].include?(@direction) -%>
-    dir: <%= @direction %>
+    direction: <%= @direction %>
 <% end -%>
 <% unless [nil, :undefined, :undef, ''].include?(@connection) -%>
     connection: <%= @connection %>

--- a/templates/router/log.conf.erb
+++ b/templates/router/log.conf.erb
@@ -1,6 +1,6 @@
 log {
     module: <%= @module %>
     enable: <%= @level %>
-    timestamp: <%= @timestamp %>
-    output: <%= @output %>
+    include-timestamp: <%= @timestamp %>
+    output-file: <%= @output %>
 }

--- a/templates/router/ssl_profile.conf.erb
+++ b/templates/router/ssl_profile.conf.erb
@@ -1,8 +1,8 @@
 ssl-profile {
     name: <%= @title %>
-    cert-db: <%= @ca %>
+    ca-cert-file: <%= @ca %>
     cert-file: <%= @cert %>
-    key-file: <%= @key %>
+    private-key-file: <%= @key %>
 <% unless [nil, :undefined, :undef, ''].include?(@password) -%>
     password: <%= @password %>
 <% end -%>


### PR DESCRIPTION
Attribute 'certDb' of entity 'sslProfile' has been deprecated. Use 'caCertFile' instead
Attribute 'keyFile' of entity 'sslProfile' has been deprecated. Use 'privateKeyFile' instead
Attribute 'dir' of entity 'linkRoute' has been deprecated. Use 'direction' instead
Attribute 'timestamp' of entity 'log' has been deprecated. Use 'includeTimestamp' instead
Attribute 'output' of entity 'log' has been deprecated. Use 'outputFile' instead