### PR TITLE
Reflect stdlib's ensure_packages default change

### DIFF
--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -182,7 +182,7 @@ describe 'qpid' do
             .that_notifies('Service[qpidd]')
             .that_requires('Package[iproute]')
           is_expected.to contain_package('iproute')
-            .with_ensure('present')
+            .with_ensure('installed')
           verify_exact_contents(catalogue, '/etc/systemd/system/qpidd.service.d/wait-for-port.conf', [
             "[Service]",
             "ExecStartPost=/bin/bash -c 'while ! ss --no-header --tcp --listening --numeric sport = :5671 | grep -q \"^LISTEN.*:5671\"; do sleep 1; done'"

--- a/spec/classes/qpid_tools_spec.rb
+++ b/spec/classes/qpid_tools_spec.rb
@@ -8,7 +8,7 @@ describe 'qpid::tools' do
       end
 
       context 'without parameters' do
-        it { is_expected.to contain_package('qpid-tools').with_ensure('present') }
+        it { is_expected.to contain_package('qpid-tools').with_ensure('installed') }
       end
 
       context 'with ensure absent' do


### PR DESCRIPTION
ensure_packages() now defaults to ensure => installed where it used to default to present. This reflects it in the tests' expectation.

https://github.com/puppetlabs/puppetlabs-stdlib/commit/77a9c07c9e64f03b12a4d8068941609f44829c8b